### PR TITLE
fixup WebpackDevServer typing import

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -9,10 +9,10 @@
  */
 
 import watchpack from "watchpack";
-import webpackDevServer from "webpack-dev-server";
 import { Compiler } from "../compiler";
 import * as oldBuiltins from "./builtins";
 import { Compilation } from "..";
+import type * as webpackDevServer from "webpack-dev-server";
 import type { Options as RspackOptions } from "./zod/_rewrite";
 import type { OptimizationConfig as Optimization } from "./zod/optimization";
 export type { RspackOptions, Optimization };


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I found this in a downstream package in rspack which [@nx/rspack](https://github.com/nrwl/nx-labs/blob/main/packages/rspack/src/executors/dev-server/dev-server.impl.ts#L32) is using `DevServer` type exported from rspack：

```typescript
import { DevServer } from '@rspack/core/dist/config';

  // If I don't typecast, it throws an error
  // that port does not exist on type DevServer
  // however, it does exist, since DevServer extends
  // WebpackDevServer.Configuration which has port
  let devServerConfig: DevServer = {
    port: options.port ?? 4200,
    hot: true,
  } as DevServer;


// rspack source code
import webpackDevServer from "webpack-dev-server";

export interface DevServer extends webpackDevServer.Configuration {
	hot?: boolean;
}
```

Default import item `webpackDevServer` doesnot provide typings exports, you have to use namespace import for 
accessing complete exports.

And fixup can be applied easily:

```typescript
import * as webpackDevServer from "webpack-dev-server";

import type * as webpackDevServer from "webpack-dev-server";
```

</details>
